### PR TITLE
Improve mobile layout at 720px and 480px breakpoints

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>

--- a/assets/shared.css
+++ b/assets/shared.css
@@ -172,5 +172,57 @@ canvas { display: block; width: 100%; height: 100%; }
   .nav-links { display: none; }
 }
 
+@media (max-width: 720px) {
+  /* Collapse every inline multi-column grid into a single column */
+  [style*="grid-template-columns"] {
+    grid-template-columns: 1fr !important;
+    gap: 20px !important;
+  }
+
+  /* Tighter section spacing */
+  .section { padding: 48px 0; }
+  .hero { padding: 48px 0 56px; }
+  .hero h1 { font-size: clamp(30px, 8vw, 44px); }
+  .hero p.lead { font-size: 15.5px; }
+
+  /* Nav: hide ghost CTAs (About, Contact), keep primary Book-a-demo */
+  .nav-cta .btn-ghost { display: none; }
+  .nav-inner { gap: 12px; }
+  .brand-logo { height: 22px; }
+
+  /* Cards / cells / metrics */
+  .cell { padding: 20px; }
+  .metric { padding: 20px 18px; }
+
+  /* Feature rows tighter */
+  .feat { padding: 16px 0; }
+
+  /* Footer */
+  .foot { padding: 48px 0 32px; margin-top: 56px; }
+  .foot-grid { gap: 32px; }
+  .foot-bottom { flex-direction: column; gap: 8px; align-items: flex-start; margin-top: 40px; }
+
+  /* About page founder portrait stays small when stacked */
+  img[src*="founder-"] { max-width: 160px !important; width: 100%; }
+
+  /* Tweaks panel: compact and further from thumb reach */
+  .tweaks { right: 12px; bottom: 12px; min-width: 180px; padding: 10px 12px; }
+
+  /* Sim frame minimum height is too tall on phones */
+  .sim-frame { min-height: 360px; }
+}
+
+@media (max-width: 480px) {
+  /* Metrics go single-column on very narrow screens */
+  .metrics { grid-template-columns: 1fr; }
+  .metric { border-right: 0; border-bottom: 1px solid var(--line); }
+  .metric:last-child { border-bottom: 0; }
+
+  .hero h1 { font-size: clamp(26px, 9vw, 36px); }
+  .section { padding: 40px 0; }
+  .wrap { padding: 0 18px; }
+  .sim-frame { min-height: 300px; }
+}
+
 /* Placeholders (striped) */
 .ph { background: repeating-linear-gradient(45deg, var(--surface-2) 0 8px, var(--surface) 8px 16px); border: 1px solid var(--line); display: flex; align-items: center; justify-content: center; color: var(--muted); font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; min-height: 180px; }

--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <style>
   .input, .select, .area { width:100%; background: var(--surface); border: 1px solid var(--line-2); color: var(--fg); padding: 12px 14px; font: inherit; font-size: 14.5px; }
   .input:focus, .select:focus, .area:focus { outline: 1px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }

--- a/federated.html
+++ b/federated.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <script>
   // Persist tweakable defaults for host to rewrite
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{

--- a/orchestration.html
+++ b/orchestration.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>

--- a/platform.html
+++ b/platform.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <script>
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
     "theme": "dark",

--- a/simulations.html
+++ b/simulations.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=5" />
+<link rel="stylesheet" href="assets/shared.css?v=6" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Pages relied heavily on inline \`grid-template-columns\` (Platform architecture layers, Simulations scenario rows, Federated metric strip, About founder grid, Contact form rows, etc.) that were not covered by the single 900px class-scoped media query, so multi-column layouts were cramped or overflowing on phones.

- **≤720px**: attribute-selector override collapses every inline multi-column grid to a single column; hero type and section padding scaled down; About/Contact ghost buttons hidden in the nav so only the logo and primary CTA remain; founder portrait capped at 160px when stacked; tweaks panel compacted; footer bottom stacks vertically.
- **≤480px**: metrics row also goes single-column, hero type steps down further, \`.wrap\` padding tightens to 18px.
- Cache version bumped: \`shared.css?v=5\` → \`?v=6\` across all seven pages.

CSS-only change to the responsive rules at the bottom of \`assets/shared.css\`; no HTML markup changes.

## Test plan

- [ ] Open each page in DevTools responsive mode at 375×667 (iPhone SE), 414×896 (iPhone 11), and 768×1024 (iPad)
- [ ] Verify nav shows only logo + \"Book a demo →\" at ≤720px
- [ ] Verify Platform architecture layers stack cleanly instead of overflowing
- [ ] Verify Simulations scenario rows read Sector / Scenario / Population stacked
- [ ] Verify About founder portrait is ~160px wide and not full-bleed
- [ ] Verify Contact form fields (Name/Email, Organization/Role, Product/Deployment) stack
- [ ] Rotate to landscape and confirm no horizontal overflow anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)