### PR TITLE
Add mobile hamburger menu with nav drawer

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -93,6 +93,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 </body>
 </html>

--- a/assets/shared.css
+++ b/assets/shared.css
@@ -68,6 +68,22 @@ img { max-width: 100%; display: block; }
 .nav-links a:hover, .nav-links a[aria-current="page"] { color: var(--fg); }
 .nav-cta { display: flex; gap: 10px; align-items: center; }
 
+/* Mobile menu toggle + drawer */
+.nav-toggle { display: none; width: 36px; height: 36px; background: transparent; border: 1px solid var(--line-2); cursor: pointer; padding: 0; position: relative; margin-left: 8px; }
+.nav-toggle:hover { border-color: var(--fg-dim); }
+.nav-toggle span { display: block; position: absolute; left: 8px; right: 8px; height: 1.5px; background: var(--fg); transition: transform .2s ease, opacity .15s ease, top .2s ease; }
+.nav-toggle span:nth-child(1) { top: 11px; }
+.nav-toggle span:nth-child(2) { top: 17px; }
+.nav-toggle span:nth-child(3) { top: 23px; }
+.nav-open .nav-toggle span:nth-child(1) { top: 17px; transform: rotate(45deg); }
+.nav-open .nav-toggle span:nth-child(2) { opacity: 0; }
+.nav-open .nav-toggle span:nth-child(3) { top: 17px; transform: rotate(-45deg); }
+
+.nav-drawer { display: none; position: absolute; top: 100%; left: 0; right: 0; background: color-mix(in oklab, var(--bg) 96%, transparent); backdrop-filter: blur(12px); border-bottom: 1px solid var(--line); padding: 8px var(--pad) 20px; flex-direction: column; }
+.nav-drawer > a:not(.btn) { color: var(--fg-dim); font-size: 15px; padding: 14px 0; border-bottom: 1px solid var(--line); text-decoration: none; }
+.nav-drawer > a:not(.btn):hover, .nav-drawer > a[aria-current="page"] { color: var(--fg); }
+.nav-drawer > a.btn { margin-top: 20px; justify-content: center; }
+
 /* Buttons */
 .btn { display: inline-flex; align-items: center; gap: 10px; padding: 10px 16px; border: 1px solid var(--line-2); color: var(--fg); font-size: 13.5px; letter-spacing: -0.005em; transition: background .15s ease, border-color .15s ease, color .15s ease; }
 .btn:hover { border-color: var(--fg-dim); }
@@ -170,6 +186,9 @@ canvas { display: block; width: 100%; height: 100%; }
   .foot-grid { grid-template-columns: 1fr 1fr; }
   .section-head { grid-template-columns: 1fr; gap: 12px; }
   .nav-links { display: none; }
+  .nav-cta .btn-ghost { display: none; }
+  .nav-toggle { display: block; }
+  .nav-open .nav-drawer { display: flex; }
 }
 
 @media (max-width: 720px) {
@@ -185,8 +204,6 @@ canvas { display: block; width: 100%; height: 100%; }
   .hero h1 { font-size: clamp(30px, 8vw, 44px); }
   .hero p.lead { font-size: 15.5px; }
 
-  /* Nav: hide ghost CTAs (About, Contact), keep primary Book-a-demo */
-  .nav-cta .btn-ghost { display: none; }
   .nav-inner { gap: 12px; }
   .brand-logo { height: 22px; }
 

--- a/assets/shared.js
+++ b/assets/shared.js
@@ -40,8 +40,13 @@
     const mount = document.getElementById('nav-mount');
     if (!mount) return;
     const cp = currentPage();
+    const drawerLinks = [
+      ...links,
+      { href: 'about.html', label: 'About' },
+      { href: 'contact.html', label: 'Contact' },
+    ];
     mount.innerHTML = `
-      <nav class="nav"><div class="wrap nav-inner">
+      <nav class="nav" id="bq-nav"><div class="wrap nav-inner">
         <a class="brand" href="index.html">
           <img class="brand-logo" src="assets/logo.png" alt="BitQubic" />
         </a>
@@ -53,8 +58,28 @@
           <a class="btn btn-ghost" href="contact.html">Contact</a>
           <a class="btn btn-primary" href="contact.html">Book a demo <span class="arr">→</span></a>
         </div>
-      </div></nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="bq-nav-drawer">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
+      <div class="nav-drawer" id="bq-nav-drawer" aria-hidden="true">
+        ${drawerLinks.map(l => `<a href="${l.href}"${cp === l.href ? ' aria-current="page"' : ''}>${l.label}</a>`).join('')}
+        <a class="btn btn-primary" href="contact.html">Book a demo <span class="arr">→</span></a>
+      </div>
+      </nav>
     `;
+
+    const nav = document.getElementById('bq-nav');
+    const toggle = nav.querySelector('.nav-toggle');
+    const drawer = nav.querySelector('.nav-drawer');
+    const setOpen = (open) => {
+      nav.classList.toggle('nav-open', open);
+      toggle.setAttribute('aria-expanded', String(open));
+      drawer.setAttribute('aria-hidden', String(!open));
+    };
+    toggle.addEventListener('click', () => setOpen(!nav.classList.contains('nav-open')));
+    drawer.querySelectorAll('a').forEach(a => a.addEventListener('click', () => setOpen(false)));
+    document.addEventListener('keydown', e => { if (e.key === 'Escape') setOpen(false); });
   }
 
   function renderFooter() {

--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <style>
   .input, .select, .area { width:100%; background: var(--surface); border: 1px solid var(--line-2); color: var(--fg); padding: 12px 14px; font: inherit; font-size: 14.5px; }
   .input:focus, .select:focus, .area:focus { outline: 1px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }
@@ -96,6 +96,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 </body>
 </html>

--- a/federated.html
+++ b/federated.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -94,6 +94,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <script>
   // Persist tweakable defaults for host to rewrite
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
@@ -311,7 +311,7 @@
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
 
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 <script src="assets/swarm.js?v=7"></script>
 <script>
   // Hero variant switch

--- a/orchestration.html
+++ b/orchestration.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -72,7 +72,7 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 <script>
   window.addEventListener('load', () => {
     const regions = [

--- a/platform.html
+++ b/platform.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <script>
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
     "theme": "dark",
@@ -103,6 +103,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 </body>
 </html>

--- a/simulations.html
+++ b/simulations.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=6" />
+<link rel="stylesheet" href="assets/shared.css?v=7" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -115,7 +115,7 @@ report = replay(run.manifest).attribute(<span style="color:#ffb23e">"insolvencie
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=11"></script>
+<script src="assets/shared.js?v=12"></script>
 <script src="assets/swarm.js?v=7"></script>
 <script>window.addEventListener('load', () => { BQSwarm.init(document.getElementById('sim'), { count: 200 }); });</script>
 </body>


### PR DESCRIPTION
## Summary

On phones and small tablets the main nav links and the About/Contact ghost buttons were hidden with no replacement, so the logo and Book-a-demo button were the only reachable navigation. This adds a hamburger toggle that opens a drawer containing every page link plus a prominent Book-a-demo button.

- **≤900px**: hamburger visible; main nav links and ghost CTAs hidden; drawer is the single navigation surface.
- **Drawer contents**: Platform, Agentic Simulations, Federated Learning, Carbon Orchestration, About, Contact, then a full-width Book-a-demo button.
- **Interactions**: tap toggle to open/close; tap a drawer link closes it; Escape key closes it. Icon morphs between ≡ and ✕.
- **Desktop (>900px)**: behaviour unchanged.
- Cache versions: \`shared.css?v=6\` → \`?v=7\`, \`shared.js?v=11\` → \`?v=12\` across all seven pages.

## Test plan

- [ ] Open at 375×667 (iPhone SE), 768×1024 (iPad portrait), and 1280×800 (desktop); confirm hamburger shows only on the first two
- [ ] Tap hamburger: drawer opens below the nav bar and lists all seven destinations plus Book-a-demo
- [ ] Tap a link: navigates and the drawer is closed on return
- [ ] Press Escape with the drawer open: drawer closes
- [ ] Confirm \`aria-expanded\` flips and the icon animates to an X
- [ ] Verify desktop nav is visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)