### PR TITLE
Hide Book-a-demo on mobile top bar and add About to footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -93,6 +93,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 </body>
 </html>

--- a/assets/shared.css
+++ b/assets/shared.css
@@ -186,7 +186,7 @@ canvas { display: block; width: 100%; height: 100%; }
   .foot-grid { grid-template-columns: 1fr 1fr; }
   .section-head { grid-template-columns: 1fr; gap: 12px; }
   .nav-links { display: none; }
-  .nav-cta .btn-ghost { display: none; }
+  .nav-cta { display: none; }
   .nav-toggle { display: block; }
   .nav-open .nav-drawer { display: flex; }
 }

--- a/assets/shared.js
+++ b/assets/shared.js
@@ -106,6 +106,7 @@
           <div>
             <h5>Company</h5>
             <ul>
+              <li><a href="about.html">About</a></li>
               <li><a href="contact.html">Contact</a></li>
             </ul>
           </div>

--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <style>
   .input, .select, .area { width:100%; background: var(--surface); border: 1px solid var(--line-2); color: var(--fg); padding: 12px 14px; font: inherit; font-size: 14.5px; }
   .input:focus, .select:focus, .area:focus { outline: 1px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }
@@ -96,6 +96,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 </body>
 </html>

--- a/federated.html
+++ b/federated.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -94,6 +94,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <script>
   // Persist tweakable defaults for host to rewrite
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
@@ -311,7 +311,7 @@
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
 
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 <script src="assets/swarm.js?v=7"></script>
 <script>
   // Hero variant switch

--- a/orchestration.html
+++ b/orchestration.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -72,7 +72,7 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 <script>
   window.addEventListener('load', () => {
     const regions = [

--- a/platform.html
+++ b/platform.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <script>
   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
     "theme": "dark",
@@ -103,6 +103,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 </body>
 </html>

--- a/simulations.html
+++ b/simulations.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="assets/shared.css?v=7" />
+<link rel="stylesheet" href="assets/shared.css?v=8" />
 <script>const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{"theme":"dark","accent":"lime","hero":"swarm"}/*EDITMODE-END*/;</script>
 </head>
 <body>
@@ -115,7 +115,7 @@ report = replay(run.manifest).attribute(<span style="color:#ffb23e">"insolvencie
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=12"></script>
+<script src="assets/shared.js?v=13"></script>
 <script src="assets/swarm.js?v=7"></script>
 <script>window.addEventListener('load', () => { BQSwarm.init(document.getElementById('sim'), { count: 200 }); });</script>
 </body>


### PR DESCRIPTION
## Summary

- Mobile top bar at ≤900px now hides the entire \`.nav-cta\` (was only hiding ghost buttons). Only the logo and hamburger remain; the Book-a-demo button lives inside the drawer alongside every other destination.
- Footer Company column adds **About** above Contact.
- Cache versions bumped: \`shared.css?v=7\` → \`?v=8\`, \`shared.js?v=12\` → \`?v=13\` across all seven pages.

## Test plan

- [ ] At ≤900px: top bar shows only logo + hamburger, no Book-a-demo button
- [ ] Open drawer: Book-a-demo button still present as the last item
- [ ] Desktop >900px: nav unchanged (About, Contact, Book-a-demo all visible)
- [ ] Footer on every page shows Company → About, Contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)