### PR TITLE
Add R&D office map, drop Ottawa head office, simplify city list

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,7 +17,7 @@
   <div class="wrap">
     <div class="tag" style="margin-bottom: 28px;">About · Established 2018</div>
     <h1 style="font-size: clamp(40px, 5vw, 64px); letter-spacing: -0.025em; line-height:1.05; margin: 0 0 28px; font-weight: 500; max-width: 20ch;">Canadian infrastructure for distributed intelligence.</h1>
-    <p style="color: var(--fg-dim); font-size: 18px; max-width: 62ch; line-height: 1.5; margin: 0 0 40px;">BitQubic Corp. was founded in 2018 to build the substrate for federated learning, carbon-aware orchestration, and agentic simulation, deployed where the data lives. Headquartered in Ottawa, with offices in Kanata and Calgary.</p>
+    <p style="color: var(--fg-dim); font-size: 18px; max-width: 62ch; line-height: 1.5; margin: 0 0 40px;">BitQubic Corp. was founded in 2018 to build the substrate for federated learning, carbon-aware orchestration, and agentic simulation, deployed where the data lives. Offices in Ottawa and Calgary.</p>
   </div>
 </section>
 
@@ -59,18 +59,13 @@
     <div class="section-head">
       <div class="tag">02 · Locations</div>
       <div>
-        <h2 class="section-title">Three offices across Canada.</h2>
+        <h2 class="section-title">Two offices across Canada.</h2>
       </div>
     </div>
-    <div class="grid grid-3">
+    <div class="grid grid-2">
       <div class="cell">
-        <div class="tag" style="color:var(--accent)">Head Office</div>
+        <div class="tag" style="color:var(--accent)">R&amp;D Office</div>
         <div style="font-size:16px; margin-top:10px; font-weight:500;">Ottawa, ON</div>
-        <div style="color:var(--fg-dim); font-size:14px; margin-top:6px; line-height:1.6;">204-78 George St<br>Ottawa, ON K1N 5W1</div>
-      </div>
-      <div class="cell">
-        <div class="tag">R&amp;D Office</div>
-        <div style="font-size:16px; margin-top:10px; font-weight:500;">Kanata, ON</div>
         <div style="color:var(--fg-dim); font-size:14px; margin-top:6px; line-height:1.6;">128-390 March Rd<br>Kanata, ON K2K 0G7</div>
       </div>
       <div class="cell">
@@ -93,6 +88,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 </body>
 </html>

--- a/assets/shared.js
+++ b/assets/shared.js
@@ -113,7 +113,7 @@
         </div>
         <div class="foot-bottom">
           <span>© 2026 BitQubic Corp.</span>
-          <span>Ottawa · Kanata · Calgary</span>
+          <span>Ottawa · Calgary</span>
         </div>
       </div></footer>
     `;

--- a/contact.html
+++ b/contact.html
@@ -81,7 +81,10 @@
         </div>
         <div style="border-top:1px solid var(--line); padding: 20px 0;">
           <div class="tag">Offices</div>
-          <div style="color:var(--fg-dim); font-size:14px; margin-top:6px; line-height:1.6;">Head Office · 204-78 George St, Ottawa, ON K1N 5W1<br>R&amp;D Office · 128-390 March Rd, Kanata, ON K2K 0G7</div>
+          <div style="color:var(--fg-dim); font-size:14px; margin-top:6px; line-height:1.6;">R&amp;D Office · 128-390 March Rd, Kanata, ON K2K 0G7</div>
+          <div style="margin-top:16px; border:1px solid var(--line); line-height:0;">
+            <iframe title="R&amp;D Office · 128-390 March Rd, Kanata, ON K2K 0G7" src="https://maps.google.com/maps?q=128-390+March+Rd,+Kanata,+ON+K2K+0G7&amp;z=15&amp;output=embed" width="100%" height="220" style="border:0; display:block;" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
         </div>
       </div>
     </div>
@@ -96,6 +99,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 </body>
 </html>

--- a/federated.html
+++ b/federated.html
@@ -94,6 +94,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 <!-- HERO: editorial variant (hidden by default) -->
 <header class="hero" data-variant="editorial" style="display:none; padding: 96px 0 96px;">
   <div class="wrap">
-    <div class="tag" style="margin-bottom:48px">ESTABLISHED 2018 · OTTAWA / KANATA / CALGARY</div>
+    <div class="tag" style="margin-bottom:48px">ESTABLISHED 2018 · OTTAWA / CALGARY</div>
     <h1 style="max-width: 18ch; margin-bottom: 40px;">Intelligence, <em>federated</em>. Compute, accountable. Simulation, at scale.</h1>
     <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items:end; border-top:1px solid var(--line); padding-top: 40px;">
       <p class="lead" style="max-width: 56ch; font-size: 18px;">BitQubic is distributed-intelligence infrastructure for organizations that need to keep their data and compute on their own premises. Three products that work together or alone: agentic simulations, federated learning, and carbon-aware scheduling.</p>
@@ -311,7 +311,7 @@
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
 
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 <script src="assets/swarm.js?v=7"></script>
 <script>
   // Hero variant switch

--- a/orchestration.html
+++ b/orchestration.html
@@ -72,7 +72,7 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 <script>
   window.addEventListener('load', () => {
     const regions = [

--- a/platform.html
+++ b/platform.html
@@ -103,6 +103,6 @@
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 </body>
 </html>

--- a/simulations.html
+++ b/simulations.html
@@ -115,7 +115,7 @@ report = replay(run.manifest).attribute(<span style="color:#ffb23e">"insolvencie
 
 <div id="foot-mount"></div>
 <div id="tweaks-mount"></div>
-<script src="assets/shared.js?v=13"></script>
+<script src="assets/shared.js?v=14"></script>
 <script src="assets/swarm.js?v=7"></script>
 <script>window.addEventListener('load', () => { BQSwarm.init(document.getElementById('sim'), { count: 200 }); });</script>
 </body>


### PR DESCRIPTION
## Summary

- **\`contact.html\`** Offices block: Head Office line (204-78 George St, Ottawa) removed. Kanata R&D address remains, with a new keyless Google Maps \`iframe\` embed (220px tall) pointing to 128-390 March Rd, Kanata.
- **Footer cities** (\`assets/shared.js\`): \`Ottawa · Kanata · Calgary\` → \`Ottawa · Calgary\`.
- **Editorial hero tag** (\`index.html:112\`): \`OTTAWA / KANATA / CALGARY\` → \`OTTAWA / CALGARY\`.
- **\`about.html\`** Locations: Head Office card removed; grid reduced from \`grid-3\` to \`grid-2\`; heading changed to \"Two offices across Canada.\"; the formerly-Kanata card now labels the city as \"Ottawa, ON\" while the street address below still reads \"128-390 March Rd, Kanata, ON K2K 0G7\" (matches the simplified city listing without losing the real address). Hero lead rewritten: \"Offices in Ottawa and Calgary.\"
- Cache bumped: \`shared.js?v=13\` → \`?v=14\` across all seven pages.

## Notes

- The map uses the keyless \`maps.google.com/maps?q=...&output=embed\` URL; Google may eventually require the official Embed API + key, at which point the \`src\` needs a swap.
- Calgary card still shows \"Address forthcoming.\" until a real address is provided.

## Test plan

- [ ] \`/contact.html\`: Offices shows only the Kanata R&D address, with a visible Google map beneath
- [ ] Footer on every page reads \"Ottawa · Calgary\"
- [ ] Homepage editorial hero (tweaks → Hero → Editorial): tag reads \"ESTABLISHED 2018 · OTTAWA / CALGARY\"
- [ ] \`/about.html\`: two location cards (Ottawa, ON with Kanata street address; Calgary, AB); heading \"Two offices across Canada.\"
- [ ] Hard-refresh on each page to confirm the v=14 bundle loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)